### PR TITLE
Add followings endpoint contracts and tests

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -84,6 +84,20 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.taonity</groupId>
+            <artifactId>spotify-contracts</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <classifier>stubs</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.taonity</groupId>
+            <artifactId>openai-contracts</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <classifier>stubs</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>

--- a/app/src/main/kotlin/org/taonity/artistinsightservice/FollowingsService.kt
+++ b/app/src/main/kotlin/org/taonity/artistinsightservice/FollowingsService.kt
@@ -2,6 +2,7 @@ package org.taonity.artistinsightservice
 
 import jakarta.validation.Validator
 import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.oauth2.client.web.client.RequestAttributeClientRegistrationIdResolver.clientRegistrationId
 import org.springframework.security.oauth2.client.web.client.RequestAttributePrincipalResolver.principal
 import org.springframework.stereotype.Service
@@ -11,10 +12,10 @@ import org.taonity.artistinsightservice.mvc.EnrichableArtistObject
 import org.taonity.artistinsightservice.mvc.FollowingsResponse
 import org.taonity.artistinsightservice.mvc.SpotifyResponse
 import org.taonity.artistinsightservice.openai.OpenAIService
-import org.taonity.artistinsightservice.persistence.user.SpotifyUserService
 import org.taonity.artistinsightservice.persistence.genre.ArtistGenreService
 import org.taonity.artistinsightservice.persistence.spotify_user_enriched_artists.SpotifyUserEnrichedArtistsService
 import org.taonity.artistinsightservice.persistence.user.SpotifyUserEntity
+import org.taonity.artistinsightservice.persistence.user.SpotifyUserService
 import org.taonity.spotify.model.ArtistObject
 import org.taonity.spotify.model.PagingArtistObject
 import java.util.ArrayList
@@ -26,7 +27,9 @@ class FollowingsService(
     private val spotifyRestClient: RestClient,
     private val openAIService: OpenAIService,
     private val spotifyUserEnrichedArtistsService: SpotifyUserEnrichedArtistsService,
-    private val validator: Validator
+    private val validator: Validator,
+    @Value("\${spotify.api-base-url}")
+    private val spotifyApiBaseUrl: String,
 ) {
     companion object {
         private val LOGGER = KotlinLogging.logger {}
@@ -110,7 +113,7 @@ class FollowingsService(
 
     private fun fetchAllPages(fetchPage: (String) -> PagingArtistObject): List<ArtistObject> {
         val allItems: MutableList<ArtistObject> = ArrayList()
-        var url: String? = "https://api.spotify.com/v1/me/following?type=artist"
+        var url: String? = "$spotifyApiBaseUrl/v1/me/following?type=artist"
 
         while (url != null) {
             val page: PagingArtistObject = fetchPage(url)

--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -34,6 +34,9 @@ app:
   minimised-http-servlet-logging: false
   initial-gpt-usages: 10
 
+spotify:
+  api-base-url: https://api.spotify.com
+
 logging:
   level:
     root: DEBUG

--- a/app/src/test/kotlin/org/taonity/artistinsightservice/mvc/FollowingsControllerTest.kt
+++ b/app/src/test/kotlin/org/taonity/artistinsightservice/mvc/FollowingsControllerTest.kt
@@ -1,0 +1,120 @@
+package org.taonity.artistinsightservice.mvc
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner
+import org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureStubRunner(
+    ids = [
+        "org.taonity:spotify-contracts:1.0-SNAPSHOT:stubs:8100",
+        "org.taonity:openai-contracts:1.0-SNAPSHOT:stubs:8101"
+    ],
+    stubsMode = StubRunnerProperties.StubsMode.LOCAL
+)
+@Sql("classpath:sql/test-data.sql")
+class FollowingsControllerTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    companion object {
+        private val OBJECT_MAPPER = jacksonObjectMapper()
+    }
+
+    @Test
+    fun `followings raw`() {
+        val session = authorizeOAuth2()
+
+        val mvcResult = mockMvc.perform(get("/followings/raw").session(session))
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val response: FollowingsResponse = OBJECT_MAPPER.readValue(mvcResult.response.contentAsString)
+
+        assertThat(response.artists).hasSize(2)
+
+        val withGenre = response.artists[0]
+        assertThat(withGenre.artistObject.id).isEqualTo("artist-with-genre")
+        assertThat(withGenre.artistObject.genres).containsExactly("metal", "rock")
+        assertThat(withGenre.genreEnriched).isFalse()
+
+        val withoutGenre = response.artists[1]
+        assertThat(withoutGenre.artistObject.id).isEqualTo("artist-without-genre")
+        assertThat(withoutGenre.artistObject.genres).isEmpty()
+        assertThat(withoutGenre.genreEnriched).isFalse()
+    }
+
+    @Test
+    fun `followings enriched`() {
+        val session = authorizeOAuth2()
+
+        val mvcResult = mockMvc.perform(get("/followings/enriched").session(session))
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val response: FollowingsResponse = OBJECT_MAPPER.readValue(mvcResult.response.contentAsString)
+
+        assertThat(response.artists).hasSize(2)
+
+        val withGenre = response.artists[0]
+        assertThat(withGenre.artistObject.id).isEqualTo("artist-with-genre")
+        assertThat(withGenre.artistObject.genres).containsExactly("metal", "rock")
+        assertThat(withGenre.genreEnriched).isFalse()
+
+        val enriched = response.artists[1]
+        assertThat(enriched.artistObject.id).isEqualTo("artist-without-genre")
+        assertThat(enriched.artistObject.genres).containsExactly(
+            "Ambient",
+            "Dungeon Synth",
+            "Dark Ambient",
+            "Electronic"
+        )
+        assertThat(enriched.genreEnriched).isTrue()
+    }
+
+    private fun authorizeOAuth2(): MockHttpSession {
+        val session = MockHttpSession()
+        val authResult = mockMvc.perform(
+            get("/oauth2/authorization/spotify-artist-insight-service").session(session)
+        )
+            .andExpect(status().is3xxRedirection)
+            .andReturn()
+        val state = getState(authResult)
+        mockMvc.perform(
+            get("/login/oauth2/code/spotify-artist-insight-service")
+                .session(session)
+                .param(
+                    "code",
+                    "AQDnprqgaHL-OgQl3T8ezARXH1UehFE0uYHbsgETI88sNI_2omVFSA6XOyMjG9W1xuTb-BqazM-iDfvgf4t9n8sYqRuJwsu2gDfc6Hv0Uyz6R7IvEkeGEAb9FzVV6vDOLSf5tm2j0ZKuoFeygYMVECTK3kvb0Ee5x7Kto-XTPcIyhAqVxbdN7ebxpFOtX-tYIQLM5p343HPAxr-mClIhbSrj-9_-t_7H3bQKJO-H7rR7ka5CvUU_YFAvcdwDjskxCZMBIotpiouflrK0n7NW"
+                )
+                .param("state", state)
+        )
+            .andExpect(status().is3xxRedirection)
+        return session
+    }
+
+    private fun getState(authenticationMvcResult: org.springframework.test.web.servlet.MvcResult): String {
+        val location = authenticationMvcResult.response.getHeader("Location")
+        val rawState = UriComponentsBuilder.fromUriString(location!!)
+            .build()
+            .queryParams
+            .getFirst("state")
+        return URLDecoder.decode(rawState, StandardCharsets.UTF_8)
+    }
+}

--- a/app/src/test/resources/application.yaml
+++ b/app/src/test/resources/application.yaml
@@ -41,6 +41,9 @@ app:
   minimised-http-servlet-logging: false
   initial-gpt-usages: 10
 
+spotify:
+  api-base-url: http://localhost:8100
+
 logging:
   level:
 #    root: DEBUG

--- a/spotify-contracts/src/test/resources/contracts/following.groovy
+++ b/spotify-contracts/src/test/resources/contracts/following.groovy
@@ -1,0 +1,40 @@
+package contracts
+
+import org.springframework.cloud.contract.spec.Contract
+
+Contract.make {
+    description "should return followed artists"
+
+    request {
+        method GET()
+        url "/v1/me/following?type=artist"
+    }
+
+    response {
+        status OK()
+        headers {
+            contentType applicationJson()
+        }
+        body(
+            artists: [
+                items: [
+                    [
+                        id: "artist-with-genre",
+                        name: "ArtistWithGenre",
+                        genres: ["metal", "rock"],
+                        href: "https://api.spotify.com/v1/artists/artist-with-genre",
+                        images: []
+                    ],
+                    [
+                        id: "artist-without-genre",
+                        name: "ArtistWithoutGenre",
+                        genres: [],
+                        href: "https://api.spotify.com/v1/artists/artist-without-genre",
+                        images: []
+                    ]
+                ],
+                next: null
+            ]
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable Spotify API base URL
- stub Spotify followings endpoint with and without genres
- test raw and enriched followings using Spotify and OpenAI stubs

## Testing
- `mvn -q -pl spotify-contracts,openai-contracts -am install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689c90864e848324beae4ed4f2143fd0