### PR TITLE
feat(frontend): revamp login page

### DIFF
--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -26,11 +26,28 @@ export default function Login() {
     return null
   }
 
+  const scopes = [
+    'Read your private profile information',
+    'See your followed artists',
+  ]
+
   return (
-    <div style={{ padding: '32px' }}>
-      <h1>Login</h1>
-      <a href={`${API_BASE}/oauth2/authorization/spotify-artist-insight-service`}>
-        <button>Login with Spotify</button>
+    <div className="login-container">
+      <h1>Artist Insight</h1>
+      <p className="tagline">
+        Easily fetch your Spotify followings and share them with friends. Start exploring and enjoy the experience!
+      </p>
+      <p>You may be redirected to Spotify to log in. This app will be able to:</p>
+      <ul className="scope-list">
+        {scopes.map((scope) => (
+          <li key={scope}>{scope}</li>
+        ))}
+      </ul>
+      <a
+        className="button"
+        href={`${API_BASE}/oauth2/authorization/spotify-artist-insight-service`}
+      >
+        Login with Spotify
       </a>
     </div>
   )

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -198,6 +198,27 @@ a.button:hover {
   margin-top: 0;
 }
 
+.login-container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 32px;
+}
+
+.scope-list {
+  list-style: disc;
+  padding-left: 20px;
+  text-align: left;
+  margin: 16px 0;
+}
+
+.tagline {
+  margin-bottom: 24px;
+}
+
 @keyframes pulse {
   0% {
     opacity: 1;


### PR DESCRIPTION
## Summary
- center and restyle login page in Spotify-inspired design
- explain Spotify scopes and redirect behavior for OAuth

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b02bdac2388324b7b1e6cb64c59337