### PR TITLE
Refactor frontend to use Route Handlers

### DIFF
--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_BACKEND_URL=http://localhost:9016
+BACKEND_URL=http://localhost:9016

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,10 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  env: {
-    NEXT_PUBLIC_BACKEND_URL:
-      process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:9016'
-  },
   images: {
     remotePatterns: [
       {

--- a/frontend/src/app/api/followings/enriched/route.ts
+++ b/frontend/src/app/api/followings/enriched/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { fetchFromBackend } from '@/lib/backend'
+
+export async function GET(req: NextRequest) {
+  const res = await fetchFromBackend(req, '/followings/enriched')
+  return new NextResponse(res.body, { status: res.status, headers: res.headers })
+}

--- a/frontend/src/app/api/followings/route.ts
+++ b/frontend/src/app/api/followings/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { fetchFromBackend } from '@/lib/backend'
+
+export async function GET(req: NextRequest) {
+  const res = await fetchFromBackend(req, '/followings')
+  return new NextResponse(res.body, { status: res.status, headers: res.headers })
+}

--- a/frontend/src/app/api/logout/route.ts
+++ b/frontend/src/app/api/logout/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { fetchFromBackend } from '@/lib/backend'
+
+export async function POST(req: NextRequest) {
+  const xsrf = req.headers.get('x-xsrf-token') ?? ''
+  const res = await fetchFromBackend(req, '/logout', {
+    method: 'POST',
+    headers: { 'X-XSRF-TOKEN': xsrf },
+  })
+  return new NextResponse(res.body, { status: res.status, headers: res.headers })
+}

--- a/frontend/src/app/api/oauth2/authorization/spotify-artist-insight-service/route.ts
+++ b/frontend/src/app/api/oauth2/authorization/spotify-artist-insight-service/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import { BACKEND_URL } from '@/lib/backend'
+
+export function GET() {
+  return NextResponse.redirect(
+    `${BACKEND_URL}/oauth2/authorization/spotify-artist-insight-service`
+  )
+}

--- a/frontend/src/app/api/user/route.ts
+++ b/frontend/src/app/api/user/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { fetchFromBackend } from '@/lib/backend'
+
+export async function GET(req: NextRequest) {
+  const res = await fetchFromBackend(req, '/user')
+  return new NextResponse(res.body, { status: res.status, headers: res.headers })
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react'
 
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || ''
 
 export default function Login() {
   const [loading, setLoading] = useState(true)
@@ -10,7 +9,7 @@ export default function Login() {
 
   // runs two times in development mode, but only once in production
   useEffect(() => {
-    fetch(`${API_BASE}/user`, { credentials: 'include' })
+    fetch('/api/user', { credentials: 'include' })
       .then((res) => {
         if (res.ok) {
           setLoggedIn(true)
@@ -41,7 +40,7 @@ export default function Login() {
         </p>
         <a
           className="button"
-          href={`${API_BASE}/oauth2/authorization/spotify-artist-insight-service`}
+          href="/api/oauth2/authorization/spotify-artist-insight-service"
         >
           Login with Spotify
         </a>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -10,7 +10,6 @@ import { CSVLink } from 'react-csv'
 import GptUsageBlock from '../components/GptUsageBlock'
 import Loading from '../components/Loading'
 
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || ''
 
 export default function Home() {
   const [user, setUser] = useState<User | null>(null)
@@ -20,7 +19,7 @@ export default function Home() {
   const [gptUsagesLeft, setGptUsagesLeft] = useState(0)
 
   const fetchUser = async () => {
-    const res = await fetch(`${API_BASE}/user`, { credentials: 'include' })
+    const res = await fetch('/api/user', { credentials: 'include' })
     if (res.status === 401) {
       window.location.href = '/login'
       return
@@ -52,7 +51,7 @@ export default function Home() {
 
   const logout = async () => {
     const xsrfToken = getCookie('XSRF-TOKEN')
-    await fetch(`${API_BASE}/logout`, {
+    await fetch('/api/logout', {
       method: 'POST',
       credentials: 'include',
       headers: xsrfToken ? { 'X-XSRF-TOKEN': xsrfToken } : {},
@@ -62,8 +61,7 @@ export default function Home() {
 
   const loadUserFollowings = async () => {
     setLoading(true)
-    const endpoint = `${API_BASE}/followings`
-    const res = await fetch(endpoint, { credentials: 'include' })
+    const res = await fetch('/api/followings', { credentials: 'include' })
     if (res.ok) {
       const jsonResponse = await res.json()
       setArtists(jsonResponse.artists)
@@ -74,9 +72,8 @@ export default function Home() {
 
   const loadEnrichedFollowings = async () => {
     setLoading(true)
-    const endpoint = `${API_BASE}/followings/enriched`
 
-    const res = await fetch(endpoint, { credentials: 'include' })
+    const res = await fetch('/api/followings/enriched', { credentials: 'include' })
     if (res.ok) {
       const jsonResponse = await res.json()
       setArtists(jsonResponse.artists)

--- a/frontend/src/lib/backend.ts
+++ b/frontend/src/lib/backend.ts
@@ -1,0 +1,27 @@
+import type { NextRequest } from 'next/server'
+
+export const BACKEND_URL = process.env.BACKEND_URL || ''
+
+export async function fetchFromBackend(
+  req: NextRequest,
+  path: string,
+  init: RequestInit = {}
+) {
+  const headers = new Headers(init.headers)
+  const cookie = req.headers.get('cookie')
+  if (cookie) {
+    headers.set('cookie', cookie)
+  }
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 6000)
+
+  try {
+    return await fetch(`${BACKEND_URL}${path}`, {
+      ...init,
+      headers,
+      signal: controller.signal,
+    })
+  } finally {
+    clearTimeout(timeout)
+  }
+}


### PR DESCRIPTION
## Summary
- Proxy backend through Next.js Route Handlers
- Remove direct backend URL usage in pages
- Add server-side fetch helper and adjust environment config
- Add AbortController-based timeout for backend requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b5e3623bd483248dc94ad6cbd676cb