### PR TITLE
feat(frontend): abort backend fetch after 6s

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ implement loading on frontend +
 add notification on simple following retrieval if an artist doesn't have genres, with estimation of gpt usages required and possible +
 fix gpt usages left in frontend +
 style login page with some description +
-add error pages for 
-sort genres in openai contracts - the sorting is not guaranteed by gpt anyway
-do I need Read your private profile information? - yes, it is required for /me
-test transactions
+add error pages for +
+fix spending gpt usages on failed openai request +
+manage advisaries in react - idk maybe later
+fix server address in browser search on server down - maybe later
+sort genres in openai contracts + the sorting is not guaranteed by gpt anyway
+do I need Read your private profile information? + yes, it is required for /me
+test transactions +
 add Donate button and the counter charge mechanism
 build modules in right order
 restructure backend code

--- a/artist-insight-service/pom.xml
+++ b/artist-insight-service/pom.xml
@@ -62,6 +62,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+            <version>1.10.2</version>
+        </dependency>
 
         <!-- Local profile & Test -->
         <dependency>

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/Advisory.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/Advisory.kt
@@ -8,16 +8,46 @@ enum class Advisory (
     private val severity: Severity,
     private val args: MutableList<String> = mutableListOf()
 ) {
-    TOO_MANY_FOLLOWERS(
-        "Too many followers",
-        "The service handles only up to 1000 followers",
+    TOO_MANY_FOLLOWINGS(
+        "Too many followings",
+        "The service handles only up to 1000 followings.",
         Severity.WARNING
     ),
     GPT_ENRICHMENT_AVAILABLE(
         "GPT enrichment available",
         "You can enrich %s followings with genres using GPT completion for free!",
         Severity.INFO
-    );
+    ),
+    OPENAI_PROBLEM(
+        "Problems with OpenAI",
+        "Sorry! We have some problems with OpenAI, some artists can't be enriched now. The fix is on the way.",
+        Severity.ERROR
+    ),
+    OPENAI_TIMEOUT(
+        "OpenAI timed out",
+        "Sorry! OpenAI timed out, we can't enrich your artist now. Please, try again later.",
+        Severity.ERROR
+    ),
+    SPOTIFY_PROBLEM(
+        "Problems with Spotify",
+        "Sorry! We have some problems with Spotify, artists cannot be retrieved. The fix is on the way.",
+        Severity.ERROR
+    ),
+    SPOTIFY_TIMEOUT(
+        "Spotify timed out",
+        "Sorry! Spotify timed out, we can't retrieve your artist now. Please, try again later.",
+        Severity.ERROR
+    ),
+    USER_GPT_USAGES_DEPLETED(
+        "User GPT usages depleted",
+        "Your GPT usage account depleted, consider donation to top up your GPT usage account.",
+        Severity.INFO
+    ),
+    GLOBAL_GPT_USAGES_DEPLETED(
+        "Global GPT usages depleted",
+        "Sorry! Global GPT usages for service depleted, you can't enrich artists now. The fix is on the way.",
+        Severity.WARNING
+    ),;
 
     fun withDetailArgs(vararg args: String): Advisory {
         this.args.addAll(args.toList())

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/ResponseAttachments.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/ResponseAttachments.kt
@@ -6,9 +6,10 @@ import org.springframework.web.context.annotation.RequestScope
 @Component
 @RequestScope
 data class ResponseAttachments(
-    val advisories: MutableList<Advisory> = mutableListOf()
+    val advisories: MutableSet<Advisory> = mutableSetOf()
 ) {
-    fun advisoryDtos(): List<AdvisoryDto> {
+    fun advisoryDtos(): Set<AdvisoryDto> {
         return advisories.map { it.toDto() }
+            .toSet()
     }
 }

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/SafePrivateUserObject.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/SafePrivateUserObject.kt
@@ -2,7 +2,6 @@ package org.taonity.artistinsightservice
 
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
-import org.taonity.spotify.model.ArtistObject
 import org.taonity.spotify.model.ImageObject
 import org.taonity.spotify.model.PrivateUserObject
 

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/EnrichedFollowingsResponse.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/EnrichedFollowingsResponse.kt
@@ -4,6 +4,6 @@ import org.taonity.artistinsightservice.AdvisoryDto
 
 data class EnrichedFollowingsResponse(
     val artists: List<EnrichableArtists>,
-    val advisories: MutableList<AdvisoryDto> = mutableListOf(),
+    val advisories: Set<AdvisoryDto> = setOf(),
     val gptUsagesLeft: Int
 )

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/ErrorResponse.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/ErrorResponse.kt
@@ -2,7 +2,6 @@ package org.taonity.artistinsightservice.mvc
 
 import org.taonity.artistinsightservice.AdvisoryDto
 
-data class FollowingsResponse(
-    val artists: List<EnrichableArtists>,
+data class ErrorResponse(
     val advisories: Set<AdvisoryDto> = setOf()
 )

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/FollowingsController.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/FollowingsController.kt
@@ -6,13 +6,11 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 import org.taonity.artistinsightservice.FollowingsService
-import org.taonity.artistinsightservice.ResponseAttachments
 import org.taonity.artistinsightservice.mvc.security.SpotifyUserPrincipal
 
 @RestController
 class FollowingsController(
     private val followingsService: FollowingsService,
-    private val responseAttachments: ResponseAttachments
 ) {
     companion object {
         private val LOGGER = KotlinLogging.logger {}
@@ -22,7 +20,6 @@ class FollowingsController(
     fun followings(@AuthenticationPrincipal principal: SpotifyUserPrincipal): ResponseEntity<FollowingsResponse> {
         LOGGER.info { "Handling /followings endpoint" }
         val followingsResponse: FollowingsResponse = followingsService.fetchRawFollowings(principal.getSpotifyId())
-        followingsResponse.advisories.addAll(responseAttachments.advisoryDtos())
         return ResponseEntity.ok(followingsResponse)
     }
 

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/GlobalExceptionHandler.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/GlobalExceptionHandler.kt
@@ -1,0 +1,46 @@
+package org.taonity.artistinsightservice.mvc
+
+import mu.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.taonity.artistinsightservice.Advisory
+import org.taonity.artistinsightservice.openai.OpenAITimeoutException
+import org.taonity.artistinsightservice.spotify.SpotifyClientException
+import org.taonity.artistinsightservice.spotify.SpotifyTimeoutException
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    companion object {
+        private val LOGGER = KotlinLogging.logger {}
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception::class)
+    fun handleException(e: Exception) {
+        LOGGER.error(e) {}
+    }
+
+    @ExceptionHandler(OpenAITimeoutException::class)
+    fun handleOpenAITimeoutException(e: OpenAITimeoutException): ResponseEntity<ErrorResponse> {
+        val errorResponse = ErrorResponse(setOf(Advisory.OPENAI_TIMEOUT.toDto()))
+        LOGGER.error(e) {}
+        return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT).body(errorResponse)
+    }
+
+    @ExceptionHandler(SpotifyClientException::class)
+    fun handleSpotifyClientException(e: SpotifyClientException): ResponseEntity<ErrorResponse> {
+        val errorResponse = ErrorResponse(setOf(Advisory.SPOTIFY_PROBLEM.toDto()))
+        LOGGER.error(e) {}
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse)
+    }
+
+    @ExceptionHandler(SpotifyTimeoutException::class)
+    fun handleSpotifyTimeoutException(e: SpotifyTimeoutException): ResponseEntity<ErrorResponse> {
+        val errorResponse = ErrorResponse(setOf(Advisory.SPOTIFY_TIMEOUT.toDto()))
+        LOGGER.error(e) {}
+        return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT).body(errorResponse)
+    }
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/SpotifyUserDto.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/SpotifyUserDto.kt
@@ -1,7 +1,6 @@
 package org.taonity.artistinsightservice.mvc
 
 import org.taonity.artistinsightservice.SafePrivateUserObject
-import org.taonity.spotify.model.PrivateUserObject
 
 data class SpotifyUserDto(
     val privateUserObject: SafePrivateUserObject,

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/security/HttpServletLoggingService.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/security/HttpServletLoggingService.kt
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service
 import org.springframework.web.util.ContentCachingRequestWrapper
 import java.nio.charset.Charset
 import java.util.*
-import java.util.AbstractMap
 import java.util.Objects.isNull
 
 @Service

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/security/RestClientErrorException.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/security/RestClientErrorException.kt
@@ -1,0 +1,19 @@
+package org.taonity.artistinsightservice.mvc.security
+
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatusCode
+
+class RestClientErrorException(
+    httpStatusCode: HttpStatusCode,
+    method: HttpMethod,
+    uri: String,
+    requestHeadersJson: String,
+    body: String
+) : RuntimeException(buildMessage(httpStatusCode, method, uri, requestHeadersJson, body)) {
+    companion object {
+        fun buildMessage(httpStatusCode: HttpStatusCode, method: HttpMethod, uri: String, requestHeadersJson: String, body: String): String {
+            return "Request failed: $httpStatusCode, [$method] $uri, request headers: $requestHeadersJson, response body: [$body]"
+        }
+    }
+
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/security/SecurityConfig.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/security/SecurityConfig.kt
@@ -8,16 +8,10 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
-import org.springframework.security.oauth2.client.web.client.OAuth2ClientHttpRequestInterceptor
-import org.springframework.security.oauth2.client.web.client.OAuth2ClientHttpRequestInterceptor.ClientRegistrationIdResolver
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.security.web.authentication.logout.LogoutFilter
 import org.springframework.security.web.csrf.*
-import org.springframework.web.client.RestClient
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 import java.util.*
@@ -76,25 +70,5 @@ class SecurityConfig(
         source.registerCorsConfiguration("/**", configuration)
         return source
     }
-
-    @Bean
-    fun restClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
-        val requestInterceptor = OAuth2ClientHttpRequestInterceptor(authorizedClientManager)
-        requestInterceptor.setClientRegistrationIdResolver(clientRegistrationIdResolver())
-
-        return RestClient.builder().requestInterceptor(requestInterceptor).build()
-    }
-
-    private fun clientRegistrationIdResolver(): ClientRegistrationIdResolver {
-        return ClientRegistrationIdResolver { request ->
-            val authentication = SecurityContextHolder.getContext().authentication
-            if (authentication is OAuth2AuthenticationToken) {
-                authentication.authorizedClientRegistrationId
-            } else {
-                null
-            }
-        }
-    }
-
 }
 

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/security/SpotifyUserPrincipal.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/mvc/security/SpotifyUserPrincipal.kt
@@ -3,7 +3,6 @@ package org.taonity.artistinsightservice.mvc.security
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.taonity.artistinsightservice.SafePrivateUserObject
-import org.taonity.spotify.model.PrivateUserObject
 
 class SpotifyUserPrincipal(
     private val authorities: Collection<GrantedAuthority>,

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/openai/OpenAIClientException.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/openai/OpenAIClientException.kt
@@ -1,0 +1,6 @@
+package org.taonity.artistinsightservice.openai
+
+class OpenAIClientException: RuntimeException {
+    constructor(message: String, ex: Exception?): super(message, ex)
+    constructor(message: String): super(message)
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/openai/OpenAIConfig.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/openai/OpenAIConfig.kt
@@ -4,13 +4,16 @@ import com.openai.client.okhttp.OpenAIOkHttpClient
 import com.openai.springboot.OpenAIClientCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.time.Duration
 
 @Configuration
 class OpenAIConfig {
     @Bean
     fun customizer(): OpenAIClientCustomizer {
         return OpenAIClientCustomizer { builder: OpenAIOkHttpClient.Builder ->
-            builder.maxRetries(3)
+            builder
+                .maxRetries(2)
+                .timeout(Duration.ofSeconds(3))
         }
     }
 }

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/openai/OpenAITimeoutException.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/openai/OpenAITimeoutException.kt
@@ -1,0 +1,6 @@
+package org.taonity.artistinsightservice.openai
+
+class OpenAITimeoutException: RuntimeException {
+    constructor(message: String, ex: Exception?): super(message, ex)
+    constructor(message: String): super(message)
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/persistence/artist/ArtistEntity.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/persistence/artist/ArtistEntity.kt
@@ -1,8 +1,10 @@
 package org.taonity.artistinsightservice.persistence.artist
 
-import jakarta.persistence.*
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
 import org.taonity.artistinsightservice.persistence.genre.ArtistGenreEntity
-import org.taonity.artistinsightservice.persistence.spotify_user_enriched_artists.SpotifyUserEnrichedArtistsEntity
 
 @Entity
 @Table(name = "artist")

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/persistence/genre/ArtistGenreRepository.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/persistence/genre/ArtistGenreRepository.kt
@@ -1,8 +1,6 @@
 package org.taonity.artistinsightservice.persistence.genre
 
-import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
-import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/persistence/user/SpotifyUserEntity.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/persistence/user/SpotifyUserEntity.kt
@@ -1,7 +1,8 @@
 package org.taonity.artistinsightservice.persistence.user
 
-import jakarta.persistence.*
-import org.taonity.artistinsightservice.persistence.spotify_user_enriched_artists.SpotifyUserEnrichedArtistsEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
 
 @Entity
 @Table(name = "spotify_user")

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/spotify/SpotifyClientException.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/spotify/SpotifyClientException.kt
@@ -1,0 +1,6 @@
+package org.taonity.artistinsightservice.spotify
+
+class SpotifyClientException: RuntimeException {
+    constructor(message: String, ex: Exception?): super(message, ex)
+    constructor(message: String): super(message)
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/spotify/SpotifyConfig.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/spotify/SpotifyConfig.kt
@@ -1,0 +1,68 @@
+package org.taonity.artistinsightservice.spotify
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.client.ClientHttpRequestFactory
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.oauth2.client.web.client.OAuth2ClientHttpRequestInterceptor
+import org.springframework.security.oauth2.client.web.client.OAuth2ClientHttpRequestInterceptor.ClientRegistrationIdResolver
+import org.springframework.web.client.RestClient
+import org.taonity.artistinsightservice.mvc.security.RestClientErrorException
+import java.nio.charset.Charset
+import java.time.Duration
+
+
+@Configuration
+class SpotifyConfig {
+
+    companion object {
+        private val objectMapper = jacksonObjectMapper()
+    }
+
+    @Bean
+    fun restClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
+        val requestInterceptor = OAuth2ClientHttpRequestInterceptor(authorizedClientManager)
+        requestInterceptor.setClientRegistrationIdResolver(clientRegistrationIdResolver())
+
+        return RestClient.builder()
+            .requestInterceptor(requestInterceptor)
+            .requestFactory(buildClientHttpRequestFactory())
+            .defaultStatusHandler(HttpStatusCode::isError) { req, res ->
+                val responseBody = String(res.body.readAllBytes(), Charset.defaultCharset())
+                val headersJson = objectMapper.writeValueAsString(req.headers)
+                throw RestClientErrorException(
+                    res.statusCode,
+                    req.method,
+                    req.uri.toString(),
+                    headersJson,
+                    responseBody
+                )
+            }
+            .build()
+    }
+
+    private fun clientRegistrationIdResolver(): ClientRegistrationIdResolver {
+        return ClientRegistrationIdResolver { request ->
+            val authentication = SecurityContextHolder.getContext().authentication
+            if (authentication is OAuth2AuthenticationToken) {
+                authentication.authorizedClientRegistrationId
+            } else {
+                null
+            }
+        }
+    }
+
+    // TODO: Find best values for timeouts
+    private fun buildClientHttpRequestFactory(): ClientHttpRequestFactory {
+        val clientHttpRequestFactory = HttpComponentsClientHttpRequestFactory()
+        clientHttpRequestFactory.setConnectTimeout(Duration.ofSeconds(2))
+        clientHttpRequestFactory.setConnectionRequestTimeout(Duration.ofSeconds(2))
+        clientHttpRequestFactory.setReadTimeout(Duration.ofSeconds(2))
+        return clientHttpRequestFactory
+    }
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/spotify/SpotifyService.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/spotify/SpotifyService.kt
@@ -1,0 +1,86 @@
+package org.taonity.artistinsightservice.spotify
+
+import jakarta.validation.Validator
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.oauth2.client.web.client.RequestAttributeClientRegistrationIdResolver.clientRegistrationId
+import org.springframework.security.oauth2.client.web.client.RequestAttributePrincipalResolver.principal
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.body
+import org.springframework.web.util.UriComponentsBuilder
+import org.taonity.artistinsightservice.Advisory
+import org.taonity.artistinsightservice.ResponseAttachments
+import org.taonity.artistinsightservice.SafeArtistObject
+import org.taonity.artistinsightservice.ValidatedArtistObject
+import org.taonity.artistinsightservice.mvc.SpotifyResponse
+import org.taonity.artistinsightservice.utils.hasCause
+import org.taonity.spotify.model.ArtistObject
+import org.taonity.spotify.model.PagingArtistObject
+import java.io.InterruptedIOException
+
+@Service
+class SpotifyService(
+    private val spotifyRestClient: RestClient,
+    private val validator: Validator,
+    @Value("\${spotify.api-base-url}")
+    private val spotifyApiBaseUrl: String,
+    private val responseAttachments: ResponseAttachments
+) {
+
+    fun fetchFollowings(): List<SafeArtistObject> {
+        return safeFetchFollowing()
+    }
+
+    private fun safeFetchFollowing() = fetchAllPages()
+        .map(ValidatedArtistObject::of)
+        .map { validatedArtistObject ->
+            val violations = validator.validate(validatedArtistObject)
+            if (violations.isEmpty()) {
+                return@map validatedArtistObject.toSafe()
+            }
+            val errorMessage = violations.joinToString("; ") { "${it.propertyPath}: ${it.message}" }
+            throw SpotifyClientException("Validation failed for artist $validatedArtistObject with error: $errorMessage")
+        }
+
+    private fun fetchAllPages(): List<ArtistObject> {
+        val allItems: MutableList<ArtistObject> = ArrayList()
+        val initialUrl = UriComponentsBuilder
+            .fromUriString("$spotifyApiBaseUrl/me/following")
+            .queryParam("type", "artist")
+            .queryParam("limit", 50)
+            .build()
+            .toUriString()
+        var url: String? = initialUrl
+
+        // TODO: implement timeout fo whole page series retrieval
+        while (url != null) {
+            if (allItems.size >= 1000) {
+                responseAttachments.advisories.add(Advisory.TOO_MANY_FOLLOWINGS)
+                break
+            }
+            val page: PagingArtistObject = fetchPageWithAuthentication(url)
+            allItems.addAll(page.items)
+            url = page.next
+        }
+
+        return allItems
+    }
+
+    private fun fetchPageWithAuthentication(uri: String): PagingArtistObject {
+        val responseSpec: RestClient.ResponseSpec = spotifyRestClient.get()
+            .uri(uri)
+            .attributes(clientRegistrationId("spotify-artist-insight-service"))
+            .attributes(principal("display_name"))
+            .retrieve()
+
+        val spotifyResponse = try {
+            responseSpec.body<SpotifyResponse<PagingArtistObject>>()!!
+        } catch (e: Exception) {
+            if (e.hasCause(InterruptedIOException::class.java)) {
+                throw SpotifyTimeoutException("Timeout while retrieving user followings", e)
+            }
+            throw SpotifyClientException("Failed to retrieve user followings", e)
+        }
+        return spotifyResponse.artists
+    }
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/spotify/SpotifyTimeoutException.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/spotify/SpotifyTimeoutException.kt
@@ -1,0 +1,6 @@
+package org.taonity.artistinsightservice.spotify
+
+class SpotifyTimeoutException: RuntimeException {
+    constructor(message: String, ex: Exception?): super(message, ex)
+    constructor(message: String): super(message)
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/utils/ValidatorExtention.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/utils/ValidatorExtention.kt
@@ -8,3 +8,7 @@ inline fun <reified T : Any> Validator.validateOrThrow(obj: T) {
         violations.joinToString("; ") { "${it.propertyPath}: ${it.message}" }
     }
 }
+
+
+fun Throwable.hasCause(clazz: Class<out Throwable>): Boolean =
+    clazz.isInstance(this) || (cause?.hasCause(clazz) ?: false)

--- a/artist-insight-service/src/main/resources/application-h2.yaml
+++ b/artist-insight-service/src/main/resources/application-h2.yaml
@@ -3,7 +3,7 @@ spring:
     hibernate:
       ddl-auto: none
   datasource:
-    url: jdbc:h2:file:./h2_db #;AUTO_SERVER=TRUE
+    url: jdbc:h2:file:./h2_db;AUTO_SERVER=TRUE
     username: sa
     password: sa
     driver-class-name: org.h2.Driver

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -258,3 +258,49 @@ a.button:hover {
     opacity: 1;
   }
 }
+
+.error-notification {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #e91429;
+  color: #fff;
+  padding: 12px 20px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  z-index: 1000;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.error-notification button {
+  background: transparent;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.not-found-container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 32px;
+}
+
+.not-found-container h1 {
+  font-size: 6rem;
+  margin: 0;
+  color: #1db954;
+}
+
+.not-found-container p {
+  color: #b3b3b3;
+  margin: 16px 0 24px;
+}
+

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div className="not-found-container">
+      <h1>404</h1>
+      <p>We couldn't find that page.</p>
+      <Link href="/" className="button">
+        Go home
+      </Link>
+    </div>
+  )
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -4,7 +4,7 @@ export default function NotFound() {
   return (
     <div className="not-found-container">
       <h1>404</h1>
-      <p>We couldn't find that page.</p>
+      <p>We couldn&apos;t find that page.</p>
       <Link href="/" className="button">
         Go home
       </Link>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,4 +1,4 @@
-use client
+'use client'
 
 import { useEffect, useState } from 'react'
 import ArtistList, { EnrichableArtistObject } from '../components/ArtistList'

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,4 +1,4 @@
-'use client'
+use client
 
 import { useEffect, useState } from 'react'
 import ArtistList, { EnrichableArtistObject } from '../components/ArtistList'
@@ -9,7 +9,7 @@ import Image from 'next/image'
 import { CSVLink } from 'react-csv'
 import GptUsageBlock from '../components/GptUsageBlock'
 import Loading from '../components/Loading'
-
+import ErrorNotification from '../components/ErrorNotification'
 
 export default function Home() {
   const [user, setUser] = useState<User | null>(null)
@@ -17,20 +17,37 @@ export default function Home() {
   const [advisories, setAdvisories] = useState<Advisory[]>([])
   const [loading, setLoading] = useState(false)
   const [gptUsagesLeft, setGptUsagesLeft] = useState(0)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const fetchUser = async () => {
-    const res = await fetch('/api/user', { credentials: 'include' })
-    if (res.status === 401) {
-      window.location.href = '/login'
-      return
-    }
-    if (res.ok) {
-      const snakeCasedUser = await res.json()
-      const camelCasedUser = keysToCamel(snakeCasedUser)
-      setUser(camelCasedUser)
-      setGptUsagesLeft(camelCasedUser.gptUsagesLeft)
-    } else {
-      window.location.href = '/login'
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 6000)
+    try {
+      const res = await fetch('/api/user', { credentials: 'include', signal: controller.signal })
+      if (res.status === 401) {
+        window.location.href = '/login'
+        return
+      }
+      if (res.status === 504) {
+        setErrorMessage('Request timed out. Please try again.')
+        return
+      }
+      if (res.ok) {
+        const snakeCasedUser = await res.json()
+        const camelCasedUser = keysToCamel(snakeCasedUser)
+        setUser(camelCasedUser)
+        setGptUsagesLeft(camelCasedUser.gptUsagesLeft)
+      } else {
+        window.location.href = '/login'
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        setErrorMessage('Request timed out. Please try again.')
+      } else {
+        setErrorMessage('Unable to connect to the server. Please check your connection.')
+      }
+    } finally {
+      clearTimeout(timeoutId)
     }
   }
 
@@ -61,26 +78,53 @@ export default function Home() {
 
   const loadUserFollowings = async () => {
     setLoading(true)
-    const res = await fetch('/api/followings', { credentials: 'include' })
-    if (res.ok) {
-      const jsonResponse = await res.json()
-      setArtists(jsonResponse.artists)
-      setAdvisories(jsonResponse.advisories)
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 6000)
+    try {
+      const res = await fetch('/api/followings', { credentials: 'include', signal: controller.signal })
+      if (res.status === 504) {
+        setErrorMessage('Request timed out. Please try again.')
+      } else if (res.ok) {
+        const jsonResponse = await res.json()
+        setArtists(jsonResponse.artists)
+        setAdvisories(jsonResponse.advisories)
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        setErrorMessage('Request timed out. Please try again.')
+      } else {
+        setErrorMessage('Unable to connect to the server. Please check your connection.')
+      }
+    } finally {
+      clearTimeout(timeoutId)
+      setLoading(false)
     }
-    setLoading(false)
   }
 
   const loadEnrichedFollowings = async () => {
     setLoading(true)
-
-    const res = await fetch('/api/followings/enriched', { credentials: 'include' })
-    if (res.ok) {
-      const jsonResponse = await res.json()
-      setArtists(jsonResponse.artists)
-      setAdvisories(jsonResponse.advisories)
-      setGptUsagesLeft(jsonResponse.gptUsagesLeft)
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 6000)
+    try {
+      const res = await fetch('/api/followings/enriched', { credentials: 'include', signal: controller.signal })
+      if (res.status === 504) {
+        setErrorMessage('Request timed out. Please try again.')
+      } else if (res.ok) {
+        const jsonResponse = await res.json()
+        setArtists(jsonResponse.artists)
+        setAdvisories(jsonResponse.advisories)
+        setGptUsagesLeft(jsonResponse.gptUsagesLeft)
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        setErrorMessage('Request timed out. Please try again.')
+      } else {
+        setErrorMessage('Unable to connect to the server. Please check your connection.')
+      }
+    } finally {
+      clearTimeout(timeoutId)
+      setLoading(false)
     }
-    setLoading(false)
   }
 
   if (!user) return <Loading />
@@ -98,6 +142,9 @@ export default function Home() {
 
   return (
     <div>
+      {errorMessage && (
+        <ErrorNotification message={errorMessage} onClose={() => setErrorMessage(null)} />
+      )}
       <div className="header">
         <div className="user-info">
           <Image

--- a/frontend/src/components/ErrorNotification.tsx
+++ b/frontend/src/components/ErrorNotification.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+type ErrorNotificationProps = {
+  message: string
+  onClose?: () => void
+}
+
+export default function ErrorNotification({ message, onClose }: ErrorNotificationProps) {
+  return (
+    <div className="error-notification">
+      <span>{message}</span>
+      {onClose && (
+        <button onClick={onClose} aria-label="Close notification">
+          ×
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/backend.ts
+++ b/frontend/src/lib/backend.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from 'next/server'
 
 export const BACKEND_URL = process.env.BACKEND_URL || ''
-const TIMEOUT = 6000
+const TIMEOUT = 600000
 
 export async function fetchFromBackend(
   req: NextRequest,

--- a/frontend/src/lib/backend.ts
+++ b/frontend/src/lib/backend.ts
@@ -1,11 +1,12 @@
 import type { NextRequest } from 'next/server'
 
 export const BACKEND_URL = process.env.BACKEND_URL || ''
+const TIMEOUT = 6000
 
 export async function fetchFromBackend(
   req: NextRequest,
   path: string,
-  init: RequestInit = {}
+  init: RequestInit = {},
 ) {
   const headers = new Headers(init.headers)
   const cookie = req.headers.get('cookie')
@@ -13,5 +14,21 @@ export async function fetchFromBackend(
     headers.set('cookie', cookie)
   }
 
-  return fetch(`${BACKEND_URL}${path}`, { ...init, headers })
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT)
+
+  try {
+    return await fetch(`${BACKEND_URL}${path}`, {
+      ...init,
+      headers,
+      signal: controller.signal,
+    })
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      return new Response(null, { status: 504 })
+    }
+    throw err
+  } finally {
+    clearTimeout(timeoutId)
+  }
 }


### PR DESCRIPTION
## Summary
- add AbortController with 6s timeout for fetchFromBackend to prevent long waits and return 504 on timeout

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b7394ab2b48324a6c390f20142e3ac