### PR TITLE
style: refresh donate page with spotify aesthetic

### DIFF
--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/donation/kofi/KofiCallbackController.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/donation/kofi/KofiCallbackController.kt
@@ -38,7 +38,6 @@ class KofiCallbackController (
 
         val message = kofiWebhookData.message
         if (message.isEmpty()) {
-            // make warn
             LOGGER.warn { "Kofi callback message is empty" }
             return
         }
@@ -50,7 +49,6 @@ class KofiCallbackController (
             val spotifyIdOpt = messageWords.stream().filter { it.length >= 26 }
                 .findFirst()
             if (spotifyIdOpt.isEmpty) {
-                // make warn
                 LOGGER.warn { "Failed to find spotifyId in kofi callback message: $message" }
                 return
             }
@@ -59,13 +57,11 @@ class KofiCallbackController (
 
         val spotifyUserEntity: SpotifyUserEntity = spotifyUserRepository.findBySpotifyIdForUpdate(spotifyId)
             ?: run {
-                // make warn
                 throw KofiCallbackHandlingException("Failed to find spotify user in db by spotifyId $spotifyId from message $message")
             }
 
         val amountString = kofiWebhookData.amount
         if (amountString.isEmpty()) {
-            // make error
             throw KofiCallbackHandlingException("Kofi callback amount field is empty")
         }
 

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/persistence/spotify_user_enriched_artists/SpotifyUserEnrichedArtistsService.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/persistence/spotify_user_enriched_artists/SpotifyUserEnrichedArtistsService.kt
@@ -17,6 +17,7 @@ class SpotifyUserEnrichedArtistsService(
     private val artistGenreRepository: ArtistGenreRepository,
     private val spotifyUserEnrichedArtistsRepository: SpotifyUserEnrichedArtistsRepository
 ) {
+    //TODO: simplify it by removing redundant entity references
     @Transactional
     fun saveEnrichedArtistsForUser(
         spotifyId: String,

--- a/artist-insight-service/src/test/resources/application-h2.yaml
+++ b/artist-insight-service/src/test/resources/application-h2.yaml
@@ -1,0 +1,12 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: none
+  datasource:
+    url: jdbc:h2:mem:db;MODE=PostgreSQL
+    username: sa
+    password: sa
+    driver-class-name: org.h2.Driver
+  flyway:
+    locations:
+      - filesystem:../templates/docker/flyway/sql/tables

--- a/artist-insight-service/src/test/resources/application-postgres.yaml
+++ b/artist-insight-service/src/test/resources/application-postgres.yaml
@@ -1,0 +1,9 @@
+postgres-url: jdbc:postgresql://localhost:5433/artist_insight_service
+
+spring:
+  datasource:
+    url: ${postgres-url}
+    username: d
+    password: d
+  flyway:
+    enabled: false

--- a/artist-insight-service/src/test/resources/application.yaml
+++ b/artist-insight-service/src/test/resources/application.yaml
@@ -2,18 +2,6 @@ server:
   port: 9016
 
 spring:
-  jpa:
-    hibernate:
-      ddl-auto: none
-  datasource:
-    url: jdbc:h2:mem:db
-    username: sa
-    password: sa
-    driver-class-name: org.h2.Driver
-  flyway:
-    locations:
-      - filesystem:../templates/docker/flyway/sql/tables
-
   security:
     oauth2:
       client:

--- a/frontend/src/app/donate/page.tsx
+++ b/frontend/src/app/donate/page.tsx
@@ -11,26 +11,74 @@ import { useEffect, useState } from 'react'
 
 export default function Donate() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
   const user = useUser(setErrorMessage);
+
+  useEffect(() => {
+    if (!copied) return
+
+    const timer = setTimeout(() => setCopied(false), 2500)
+    return () => clearTimeout(timer)
+  }, [copied])
 
   if (!user) return <Loading />
 
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(user.privateUserObject.id)
+      setCopied(true)
+    } catch (err) {
+      setErrorMessage('We could not copy your supporter ID. Please copy it manually.')
+    }
+  }
 
   return (
-    <div>
+    <div className="donate-page">
       {errorMessage && (
         <ErrorNotification message={errorMessage} onClose={() => setErrorMessage(null)} />
       )}
-      <Header user={user}/>
-      <div className="donation-instructions">
-        SOme donation info and instructions
-      </div>
-      <div className="user-id-box">
-        {user.privateUserObject.id}
-      </div>
-      <div>
-        <KoFiButton username="N4N11KVW3E" label="Support me on Ko-fi" />
-      </div>
+      <Header user={user} />
+      <main className="donate-content">
+        <section className="donate-hero">
+          <h1>Fuel the Artist Insight groove</h1>
+          <p>
+            Every donation helps us surface fresh artists, craft better insights, and keep your release
+            radar ahead of the crowd.
+          </p>
+        </section>
+
+        <section className="user-id-section">
+          <div className="user-id-header">
+            <h2>Your supporter ID</h2>
+            <p>Include this ID with your donation so we can shout you out with a personalized thank you.</p>
+          </div>
+          <div className="user-id-box" role="group" aria-label="Supporter ID">
+            <span className="user-id-value">{user.privateUserObject.id}</span>
+            <button type="button" className="copy-button" onClick={handleCopy} aria-label="Copy supporter ID">
+              Copy
+            </button>
+          </div>
+          <span className="copy-success" role="status" aria-live="polite">
+            {copied ? 'Supporter ID copied to clipboard!' : '\u00A0'}
+          </span>
+        </section>
+
+        <section className="support-grid" aria-label="Ways to support">
+          <article className="support-card kofi-card">
+            <h3>Buy us a Ko-fi</h3>
+            <p>Keep the playlists spinning by treating the team to a fresh brew.</p>
+            <KoFiButton username="N4N11KVW3E" label="Support me on Ko-fi" />
+          </article>
+          <article className="support-card placeholder-card">
+            <h3>Spread the word</h3>
+            <p>Share Artist Insight with friends who crave curated discoveries.</p>
+          </article>
+          <article className="support-card placeholder-card">
+            <h3>Stay in tune</h3>
+            <p>Follow us on social to catch upcoming features and drop feedback.</p>
+          </article>
+        </section>
+      </main>
     </div>
   )
 }

--- a/frontend/src/app/donate/page.tsx
+++ b/frontend/src/app/donate/page.tsx
@@ -39,18 +39,11 @@ export default function Donate() {
       )}
       <Header user={user} />
       <main className="donate-content">
-        <section className="donate-hero">
-          <h1>Fuel the Artist Insight groove</h1>
-          <p>
-            Every donation helps us surface fresh artists, craft better insights, and keep your release
-            radar ahead of the crowd.
-          </p>
-        </section>
-
         <section className="user-id-section">
           <div className="user-id-header">
             <h2>Your supporter ID</h2>
-            <p>Include this ID with your donation so we can shout you out with a personalized thank you.</p>
+            <p>Put this ID in your "Your message" form in Ko-fi and the service will be able to top up your GPT usages account</p>
+            <p>If you have not received GPT usages after donation, please reach the developer in email artiom.diulgher@gmail.com with your supporter ID</p>
           </div>
           <div className="user-id-box" role="group" aria-label="Supporter ID">
             <span className="user-id-value">{user.privateUserObject.id}</span>
@@ -66,7 +59,8 @@ export default function Donate() {
         <section className="support-grid" aria-label="Ways to support">
           <article className="support-card kofi-card">
             <h3>Buy us a Ko-fi</h3>
-            <p>Keep the playlists spinning by treating the team to a fresh brew.</p>
+            <p>Donate the developer to make him deliver new features</p>
+            <p>1 USD = 10 GPT usages</p>
             <KoFiButton username="N4N11KVW3E" label="Support me on Ko-fi" />
           </article>
           <article className="support-card placeholder-card">

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -198,6 +198,191 @@ a.button:hover {
   margin-top: 0;
 }
 
+.donate-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.donate-content {
+  padding: 32px;
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.donate-hero {
+  background: linear-gradient(135deg, rgba(30, 185, 84, 0.18), rgba(29, 185, 84, 0));
+  border: 1px solid rgba(30, 185, 84, 0.35);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+  border-radius: 18px;
+  padding: 36px;
+  backdrop-filter: blur(8px);
+}
+
+.donate-hero h1 {
+  margin: 0 0 12px;
+  font-size: 2.5rem;
+  letter-spacing: 0.02em;
+}
+
+.donate-hero p {
+  margin: 0;
+  color: #d1d1d1;
+  line-height: 1.6;
+}
+
+.user-id-section {
+  background: rgba(24, 24, 24, 0.9);
+  border-radius: 16px;
+  padding: 28px 32px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+  border: 1px solid #282828;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.user-id-header h2 {
+  margin: 0 0 6px;
+  font-size: 1.6rem;
+}
+
+.user-id-header p {
+  margin: 0;
+  color: #b3b3b3;
+  line-height: 1.5;
+}
+
+.user-id-box {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  background: rgba(40, 40, 40, 0.75);
+  padding: 18px 22px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.user-id-value {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  color: #1db954;
+  word-break: break-all;
+}
+
+.copy-button {
+  background-color: #1db954;
+  color: #191414;
+  padding: 10px 22px;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  box-shadow: 0 8px 18px rgba(30, 185, 84, 0.25);
+}
+
+.copy-button:hover {
+  transform: translateY(-1px);
+  background-color: #1ed760;
+}
+
+.copy-button:active {
+  transform: translateY(0);
+}
+
+.copy-success {
+  font-size: 0.9rem;
+  color: #1db954;
+  min-height: 1em;
+}
+
+.support-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.support-card {
+  background: rgba(24, 24, 24, 0.92);
+  border-radius: 18px;
+  padding: 28px 24px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 220px;
+}
+
+.support-card h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.support-card p {
+  margin: 0;
+  color: #b3b3b3;
+  line-height: 1.5;
+}
+
+.support-card.placeholder-card {
+  background: rgba(29, 185, 84, 0.08);
+  border: 1px solid rgba(29, 185, 84, 0.22);
+}
+
+.support-card.placeholder-card h3 {
+  color: #1ed760;
+}
+
+.kofi-card {
+  background: rgba(40, 40, 40, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.kofi-card > :last-child {
+  margin-top: auto;
+}
+
+@media (max-width: 1024px) {
+  .donate-content {
+    padding: 24px;
+  }
+
+  .support-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .donate-content {
+    padding: 20px;
+  }
+
+  .donate-hero {
+    padding: 28px;
+  }
+
+  .user-id-box {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .copy-button {
+    width: 100%;
+  }
+
+  .support-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .login-container {
   min-height: 100vh;
   display: flex;


### PR DESCRIPTION
## Summary
- redesign the donate page with spotify-inspired hero, supporter ID section, and support grid
- add clipboard copy interaction for the supporter ID with inline feedback
- extend global styles with responsive donate page layout, cards, and copy button styling while preserving Ko-fi button look

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d1577104188324a0e3c9fff74a22ce