### PR TITLE
Add actuator-based health monitoring for external services

### DIFF
--- a/artist-insight-service/pom.xml
+++ b/artist-insight-service/pom.xml
@@ -34,6 +34,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/Main.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/Main.kt
@@ -2,8 +2,10 @@ package org.taonity.artistinsightservice
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
+@EnableScheduling
 class Main
 
 fun main(args: Array<String>) {

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/ExternalServiceHealthPinger.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/ExternalServiceHealthPinger.kt
@@ -1,0 +1,7 @@
+package org.taonity.artistinsightservice.health
+
+interface ExternalServiceHealthPinger {
+    val name: String
+
+    fun ping(): HealthCheckResult
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/ExternalServicesHealthContributor.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/ExternalServicesHealthContributor.kt
@@ -1,0 +1,32 @@
+package org.taonity.artistinsightservice.health
+
+import org.springframework.boot.actuate.health.CompositeHealthContributor
+import org.springframework.boot.actuate.health.HealthContributor
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.actuate.health.NamedContributor
+import org.springframework.stereotype.Component
+
+@Component("externalServices")
+class ExternalServicesHealthContributor(
+    monitor: ExternalServicesHealthMonitor
+) : CompositeHealthContributor {
+
+    private val contributors: Map<String, HealthIndicator> = monitor.serviceNames()
+        .associateWith { serviceName -> CachedHealthIndicator(monitor, serviceName) }
+
+    override fun getContributor(name: String): HealthContributor? = contributors[name]
+
+    override fun iterator(): MutableIterator<NamedContributor<HealthContributor>> {
+        return contributors.entries
+            .map { (name, indicator) -> NamedContributor.of(name, indicator) }
+            .toMutableList()
+            .iterator()
+    }
+
+    private class CachedHealthIndicator(
+        private val monitor: ExternalServicesHealthMonitor,
+        private val serviceName: String
+    ) : HealthIndicator {
+        override fun health() = monitor.getHealth(serviceName)
+    }
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/ExternalServicesHealthMonitor.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/ExternalServicesHealthMonitor.kt
@@ -1,0 +1,84 @@
+package org.taonity.artistinsightservice.health
+
+import jakarta.annotation.PostConstruct
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.Status
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.util.LinkedHashMap
+import java.util.concurrent.ConcurrentHashMap
+
+@Service
+class ExternalServicesHealthMonitor(
+    private val pingers: List<ExternalServiceHealthPinger>,
+    @Value("\${health.external.refresh-interval-ms:60000}")
+    private val refreshIntervalMs: Long,
+    @Value("\${health.external.initial-delay-ms:0}")
+    private val initialDelayMs: Long
+) {
+
+    companion object {
+        private val LOGGER = KotlinLogging.logger {}
+    }
+
+    private val cache = ConcurrentHashMap<String, Health>()
+    private val pingerByName = pingers.associateBy { it.name }
+    private val serviceNames = pingerByName.keys.sorted()
+
+    @PostConstruct
+    fun initialise() {
+        LOGGER.info { "Running initial external service health checks" }
+        refreshAll()
+    }
+
+    @Scheduled(
+        initialDelayString = "\${health.external.initial-delay-ms:0}",
+        fixedDelayString = "\${health.external.refresh-interval-ms:60000}"
+    )
+    fun scheduledRefresh() {
+        refreshAll()
+    }
+
+    private fun refreshAll() {
+        serviceNames.forEach { serviceName ->
+            val pinger = pingerByName.getValue(serviceName)
+            val health = buildHealth(pinger)
+            cache[serviceName] = health
+            LOGGER.debug { "Updated health status for $serviceName to ${health.status}" }
+        }
+    }
+
+    private fun buildHealth(pinger: ExternalServiceHealthPinger): Health {
+        val result = try {
+            pinger.ping()
+        } catch (exception: Exception) {
+            LOGGER.error(exception) { "Health pinger ${pinger.name} threw an unexpected exception" }
+            HealthCheckResult(
+                Status.DOWN,
+                mapOf("error" to (exception.message ?: exception::class.simpleName))
+            )
+        }
+
+        val details = LinkedHashMap(result.details)
+        details["lastCheckedAt"] = Instant.now().toString()
+        details["refreshIntervalMs"] = refreshIntervalMs
+        details["initialDelayMs"] = initialDelayMs
+
+        return Health.status(result.status).withDetails(details).build()
+    }
+
+    fun getHealth(name: String): Health {
+        return cache[name] ?: Health.unknown()
+            .withDetail("message", "No health check result recorded yet")
+            .build()
+    }
+
+    fun snapshot(): Map<String, Health> {
+        return serviceNames.associateWith { serviceName -> getHealth(serviceName) }
+    }
+
+    fun serviceNames(): List<String> = serviceNames
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/HealthCheckResult.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/HealthCheckResult.kt
@@ -1,0 +1,8 @@
+package org.taonity.artistinsightservice.health
+
+import org.springframework.boot.actuate.health.Status
+
+data class HealthCheckResult(
+    val status: Status,
+    val details: Map<String, Any?>
+)

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/HttpExternalServiceHealthPinger.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/HttpExternalServiceHealthPinger.kt
@@ -1,0 +1,77 @@
+package org.taonity.artistinsightservice.health
+
+import mu.KotlinLogging
+import org.springframework.boot.actuate.health.Status
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.time.Instant
+import java.util.LinkedHashMap
+
+abstract class HttpExternalServiceHealthPinger(
+    private val requestTimeout: Duration
+) : ExternalServiceHealthPinger {
+
+    companion object {
+        private val LOGGER = KotlinLogging.logger {}
+        private const val MAX_BODY_PREVIEW_CHARS = 160
+    }
+
+    private val httpClient: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(requestTimeout)
+        .build()
+
+    protected fun performGet(
+        url: String,
+        headers: Map<String, String> = emptyMap(),
+        healthyStatusPredicate: (Int) -> Boolean = { statusCode -> statusCode in 200..299 },
+        detailAugmentor: (HttpResponse<String>, MutableMap<String, Any?>) -> Unit = { _, _ -> }
+    ): HealthCheckResult {
+        val requestBuilder = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .timeout(requestTimeout)
+            .GET()
+
+        headers.forEach { (key, value) ->
+            requestBuilder.header(key, value)
+        }
+
+        val request = requestBuilder.build()
+        val start = Instant.now()
+
+        return try {
+            val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8))
+            val elapsedMs = Duration.between(start, Instant.now()).toMillis()
+            val details = LinkedHashMap<String, Any?>()
+            details["url"] = url
+            details["statusCode"] = response.statusCode()
+            details["responseTimeMs"] = elapsedMs
+
+            val healthy = healthyStatusPredicate(response.statusCode())
+
+            if (!healthy) {
+                val bodyPreview = response.body().take(MAX_BODY_PREVIEW_CHARS)
+                details["responsePreview"] = bodyPreview
+            }
+
+            detailAugmentor(response, details)
+
+            HealthCheckResult(
+                status = if (healthy) Status.UP else Status.DOWN,
+                details = details
+            )
+        } catch (exception: Exception) {
+            val elapsedMs = Duration.between(start, Instant.now()).toMillis()
+            LOGGER.warn(exception) { "Health check failed for $url" }
+            val details = mapOf(
+                "url" to url,
+                "responseTimeMs" to elapsedMs,
+                "error" to (exception.message ?: exception::class.simpleName)
+            )
+            HealthCheckResult(Status.DOWN, details)
+        }
+    }
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/KoFiHealthPinger.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/KoFiHealthPinger.kt
@@ -1,0 +1,31 @@
+package org.taonity.artistinsightservice.health
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class KoFiHealthPinger(
+    @Value("\${health.external.kofi.health-url:https://ko-fi.com}")
+    private val kofiHealthUrl: String,
+    @Value("\${health.external.request-timeout-ms:3000}")
+    requestTimeoutMs: Long
+) : HttpExternalServiceHealthPinger(Duration.ofMillis(requestTimeoutMs)) {
+
+    override val name: String = "kofi"
+
+    override fun ping(): HealthCheckResult {
+        return performGet(
+            url = kofiHealthUrl,
+            healthyStatusPredicate = { statusCode -> statusCode in 200..399 },
+            detailAugmentor = { response, details ->
+                if (response.statusCode() in 300..399) {
+                    val redirect = response.headers().firstValue("Location").orElse(null)
+                    if (!redirect.isNullOrBlank()) {
+                        details["redirectLocation"] = redirect
+                    }
+                }
+            }
+        )
+    }
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/LivenessHealthIndicator.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/LivenessHealthIndicator.kt
@@ -1,0 +1,29 @@
+package org.taonity.artistinsightservice.health
+
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+
+@Component("liveness")
+class LivenessHealthIndicator : HealthIndicator {
+
+    private val startedAt: Instant = Instant.now()
+
+    override fun health(): Health {
+        val uptime = Duration.between(startedAt, Instant.now())
+        return Health.up()
+            .withDetail("startedAt", startedAt.toString())
+            .withDetail("uptimeSeconds", uptime.seconds)
+            .withDetail("uptimeHumanReadable", formatDuration(uptime))
+            .build()
+    }
+
+    private fun formatDuration(duration: Duration): String {
+        val hours = duration.toHours()
+        val minutes = duration.toMinutesPart()
+        val seconds = duration.toSecondsPart()
+        return String.format("%02dh %02dm %02ds", hours, minutes, seconds)
+    }
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/OpenAIHealthPinger.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/OpenAIHealthPinger.kt
@@ -1,0 +1,65 @@
+package org.taonity.artistinsightservice.health
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.actuate.health.Status
+import org.springframework.stereotype.Component
+import java.time.Duration
+import kotlin.sequences.asSequence
+
+@Component
+class OpenAIHealthPinger(
+    @Value("\${health.external.openai.health-url:https://api.openai.com/v1/models}")
+    private val openAiHealthUrl: String,
+    @Value("\${openai.api-key:}")
+    private val apiKey: String,
+    @Value("\${health.external.request-timeout-ms:3000}")
+    requestTimeoutMs: Long
+) : HttpExternalServiceHealthPinger(Duration.ofMillis(requestTimeoutMs)) {
+
+    companion object {
+        private val LOGGER = KotlinLogging.logger {}
+        private val objectMapper = jacksonObjectMapper()
+    }
+
+    override val name: String = "openai"
+
+    override fun ping(): HealthCheckResult {
+        if (apiKey.isBlank()) {
+            return HealthCheckResult(
+                Status.DOWN,
+                mapOf(
+                    "url" to openAiHealthUrl,
+                    "message" to "OpenAI API key is not configured"
+                )
+            )
+        }
+
+        return performGet(
+            url = openAiHealthUrl,
+            headers = mapOf(
+                "Authorization" to "Bearer $apiKey",
+                "Accept" to "application/json"
+            ),
+            detailAugmentor = { response, details ->
+                if (response.statusCode() in 200..299) {
+                    try {
+                        val root = objectMapper.readTree(response.body())
+                        val modelsNode = root.path("data")
+                        if (modelsNode.isArray) {
+                            details["modelCount"] = modelsNode.size()
+                            val firstModel = modelsNode.elements().asSequence().firstOrNull()?.path("id")?.asText()
+                            if (!firstModel.isNullOrBlank()) {
+                                details["firstModel"] = firstModel
+                            }
+                        }
+                    } catch (exception: Exception) {
+                        LOGGER.warn(exception) { "Failed to parse OpenAI models response" }
+                        details["parsingError"] = exception.message
+                    }
+                }
+            }
+        )
+    }
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/ReadinessHealthIndicator.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/ReadinessHealthIndicator.kt
@@ -1,0 +1,38 @@
+package org.taonity.artistinsightservice.health
+
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.actuate.health.Status
+import org.springframework.stereotype.Component
+import java.util.LinkedHashMap
+
+@Component("readiness")
+class ReadinessHealthIndicator(
+    private val externalServicesHealthMonitor: ExternalServicesHealthMonitor
+) : HealthIndicator {
+
+    override fun health(): Health {
+        val snapshot = externalServicesHealthMonitor.snapshot()
+        if (snapshot.isEmpty()) {
+            return Health.unknown()
+                .withDetail("message", "No external health checks completed yet")
+                .build()
+        }
+
+        val allUp = snapshot.values.all { it.status == Status.UP }
+        val builder = if (allUp) Health.up() else Health.down()
+
+        val externalDetails = snapshot.mapValues { (_, health) ->
+            val details = LinkedHashMap<String, Any?>()
+            details["status"] = health.status.code
+            health.details.forEach { (key, value) ->
+                details[key] = value
+            }
+            details
+        }
+
+        builder.withDetail("externalServices", externalDetails)
+
+        return builder.build()
+    }
+}

--- a/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/SpotifyHealthPinger.kt
+++ b/artist-insight-service/src/main/kotlin/org/taonity/artistinsightservice/health/SpotifyHealthPinger.kt
@@ -1,0 +1,30 @@
+package org.taonity.artistinsightservice.health
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class SpotifyHealthPinger(
+    @Value("\${health.external.spotify.health-url:https://api.spotify.com/v1}")
+    private val spotifyHealthUrl: String,
+    @Value("\${health.external.request-timeout-ms:3000}")
+    requestTimeoutMs: Long
+) : HttpExternalServiceHealthPinger(Duration.ofMillis(requestTimeoutMs)) {
+
+    override val name: String = "spotify"
+
+    override fun ping(): HealthCheckResult {
+        return performGet(
+            url = spotifyHealthUrl,
+            healthyStatusPredicate = { statusCode ->
+                statusCode in 200..299 || statusCode == 401 || statusCode == 403
+            },
+            detailAugmentor = { response, details ->
+                if (response.statusCode() == 401 || response.statusCode() == 403) {
+                    details["note"] = "Received ${response.statusCode()} indicating OAuth token is required for full access."
+                }
+            }
+        )
+    }
+}

--- a/artist-insight-service/src/main/resources/application-prod-openai.yaml
+++ b/artist-insight-service/src/main/resources/application-prod-openai.yaml
@@ -1,3 +1,8 @@
 openai:
   api-key: ${OPENAI_API_KEY}
   base-url: https://api.openai.com/v1
+
+health:
+  external:
+    openai:
+      health-url: https://api.openai.com/v1/models

--- a/artist-insight-service/src/main/resources/application-prod-spotify.yaml
+++ b/artist-insight-service/src/main/resources/application-prod-spotify.yaml
@@ -21,3 +21,8 @@ app:
 
 spotify:
   api-base-url: https://api.spotify.com/v1
+
+health:
+  external:
+    spotify:
+      health-url: https://api.spotify.com/v1

--- a/artist-insight-service/src/main/resources/application-stub-kofi.yaml
+++ b/artist-insight-service/src/main/resources/application-stub-kofi.yaml
@@ -2,3 +2,8 @@ spring:
   mvc:
     favicon:
       enabled: false
+
+health:
+  external:
+    kofi:
+      health-url: https://ko-fi.com

--- a/artist-insight-service/src/main/resources/application-stub-openai.yaml
+++ b/artist-insight-service/src/main/resources/application-stub-openai.yaml
@@ -2,6 +2,11 @@ openai:
   api-key: "mock-api-key"
   base-url: http://localhost:8101/v1
 
+health:
+  external:
+    openai:
+      health-url: http://localhost:8101/v1/models
+
 stubrunner:
   stubs-mode: LOCAL
       

--- a/artist-insight-service/src/main/resources/application-stub-spotify.yaml
+++ b/artist-insight-service/src/main/resources/application-stub-spotify.yaml
@@ -22,6 +22,11 @@ app:
 spotify:
   api-base-url: http://localhost:8100/v1
 
+health:
+  external:
+    spotify:
+      health-url: http://localhost:8100/v1
+
 stubrunner:
   stubs-mode: LOCAL
 

--- a/artist-insight-service/src/main/resources/application.yaml
+++ b/artist-insight-service/src/main/resources/application.yaml
@@ -6,6 +6,34 @@ app:
   initial-user-gpt-usages: 10
   initial-global-gpt-usages: 50
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: always
+      probes:
+        enabled: true
+      group:
+        liveness:
+          include: livenessState,liveness
+        readiness:
+          include: readinessState,readiness
+
+health:
+  external:
+    refresh-interval-ms: 60000
+    initial-delay-ms: 0
+    request-timeout-ms: 3000
+    spotify:
+      health-url: ${spotify.api-base-url:https://api.spotify.com/v1}
+    openai:
+      health-url: ${openai.base-url:https://api.openai.com/v1}/models
+    kofi:
+      health-url: https://ko-fi.com
+
 #logging:
 #  level:
 #    root: TRACE


### PR DESCRIPTION
## Summary
- add Spring Boot Actuator support and enable scheduling in the service
- implement cached HTTP pingers for Spotify, OpenAI, and Ko-Fi with composite health contributors plus liveness/readiness indicators
- expose actuator groups and health URLs across profiles so /actuator/health, /actuator/health/liveness, and /actuator/health/readiness use cached data

## Testing
- `mvn test` *(fails: missing dependent modules when run for this module alone)*

------
https://chatgpt.com/codex/tasks/task_b_68d7cce9f1b08324975beb7a25d7ad56